### PR TITLE
feat: Implement GetLibraryIDTool with Context7 API integration

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,150 @@
+# GetLibraryIDTool Implementation
+
+This document describes the implementation of the GetLibraryIDTool (which is implemented as the `resolve_library_id` tool) for the Context7 A2A Agent.
+
+## Overview
+
+The `resolve_library_id` tool has been implemented to directly integrate with the Context7 API, providing library search and resolution capabilities similar to the official Context7 MCP server.
+
+## Implementation Details
+
+### Tools Implemented
+
+#### 1. resolve_library_id
+- **Purpose**: Resolves library names to Context7-compatible library IDs
+- **Input Parameter**: `libraryName` (string) - Library name to search for
+- **Output**: JSON response containing the selected library ID and metadata
+
+#### 2. get_library_docs (Enhanced)
+- **Purpose**: Fetches documentation for a specific library
+- **Input Parameters**: 
+  - `context7CompatibleLibraryID` (string, required) - Library ID in format `/org/project`
+  - `tokens` (number, optional) - Maximum tokens to retrieve (default: 10000)
+  - `topic` (string, optional) - Topic to focus documentation on
+- **Output**: JSON response containing the documentation content
+
+### Architecture
+
+#### Direct API Integration
+Instead of using MCP protocol communication, this implementation directly calls the Context7 REST APIs:
+
+- **Search API**: `GET https://context7.com/api/v1/search?query={query}`
+- **Documentation API**: `GET https://context7.com/api/v1/{libraryId}?tokens={tokens}&topic={topic}&type=txt`
+
+#### Authentication
+- Uses `Authorization: Bearer {apiKey}` header
+- API key retrieved from `CONTEXT7_API_KEY` environment variable
+- User-Agent set to `documentation-agent/0.1.0`
+
+### Library Selection Logic
+
+The `resolve_library_id` tool implements intelligent library selection based on the Context7 MCP server patterns:
+
+1. **Exact Match Priority**: First looks for exact title matches (case-insensitive)
+2. **Scoring System**: If no exact match, scores libraries based on:
+   - Documentation coverage (`totalSnippets` count)
+   - Trust score (7-10 range, weighted heavily)
+   - State (prioritizes "finalized" libraries)
+3. **Fallback**: Selects the first result if no scoring applies
+
+### Response Format
+
+#### resolve_library_id Response
+```json
+{
+  "selectedLibraryID": "/vercel/next.js",
+  "selectedLibrary": {
+    "id": "/vercel/next.js",
+    "title": "Next.js",
+    "description": "The React Framework for Production",
+    "totalSnippets": 150,
+    "totalTokens": 50000,
+    "state": "finalized",
+    "lastUpdateDate": "2025-01-15T10:30:00Z",
+    "trustScore": 9,
+    "stars": 120000
+  },
+  "allMatches": [...],
+  "totalMatches": 5
+}
+```
+
+#### get_library_docs Response
+```json
+{
+  "libraryID": "/vercel/next.js",
+  "documentation": "# Next.js Documentation\n\nNext.js is a React framework...",
+  "tokens": 10000,
+  "actualTokens": 8500,
+  "topic": "routing"
+}
+```
+
+### Error Handling
+
+Both tools implement comprehensive error handling:
+
+- **Missing API Key**: Returns JSON error message
+- **Invalid API Key**: Returns 401 error with helpful message
+- **Library Not Found**: Returns 404 error with context
+- **Network Issues**: Returns descriptive error messages
+- **Empty Results**: Returns appropriate not found messages
+
+### Configuration
+
+#### Environment Variables
+- `CONTEXT7_API_KEY`: Required API key for Context7 service
+
+#### Dependencies
+- `github.com/go-resty/resty/v2`: HTTP client library (already available in project)
+- Standard Go libraries: `encoding/json`, `net/http`, `os`, `strings`, `strconv`
+
+## Usage Examples
+
+### Resolving a Library ID
+```go
+args := map[string]any{
+    "libraryName": "react",
+}
+result, err := ResolveLibraryIDHandler(ctx, args)
+```
+
+### Fetching Documentation
+```go
+args := map[string]any{
+    "context7CompatibleLibraryID": "/facebook/react",
+    "tokens": 15000,
+    "topic": "hooks",
+}
+result, err := GetLibraryDocsHandler(ctx, args)
+```
+
+## Testing
+
+To test the implementation:
+
+1. Set the `CONTEXT7_API_KEY` environment variable
+2. Build and run the agent
+3. Use the A2A protocol to call the tools with test parameters
+
+## Compatibility
+
+This implementation maintains full compatibility with:
+- Context7 MCP server tool schemas
+- Context7 API response formats
+- ADL (Agent Definition Language) specifications
+- A2A (Agent-to-Agent) protocol requirements
+
+## Performance Considerations
+
+- Direct API calls eliminate MCP protocol overhead
+- HTTP client reuse for efficiency
+- Minimal response processing and JSON marshaling
+- Error responses avoid network calls when possible
+
+## Security
+
+- API key handled securely through environment variables
+- Input validation on all parameters
+- Proper HTTP status code handling
+- No sensitive information logged or exposed

--- a/agent.yaml
+++ b/agent.yaml
@@ -18,25 +18,31 @@ spec:
     temperature: 0.7
   tools:
     - name: resolve_library_id
-      description: "Resolves library by its id"
+      description: "Resolves library name to Context7-compatible library ID and returns matching libraries"
       schema:
         type: object
         properties:
-          id:
+          libraryName:
             type: string
-            description: "Library ID"
+            description: "Library name to search for and retrieve a Context7-compatible library ID"
         required:
-          - id
+          - libraryName
     - name: get_library_docs
-      description: "Get the docs for the specific library"
+      description: "Fetches up-to-date documentation for a library using Context7-compatible library ID"
       schema:
         type: object
         properties:
-          library:
+          context7CompatibleLibraryID:
             type: string
-            description: "Library Name"
+            description: "Exact Context7-compatible library ID (e.g., '/mongodb/docs', '/vercel/next.js', '/supabase/supabase') retrieved from resolve_library_id or directly from user query in the format '/org/project' or '/org/project/version'"
+          tokens:
+            type: number
+            description: "Maximum number of tokens of documentation to retrieve (default: 10000). Higher values provide more context but consume more tokens"
+          topic:
+            type: string
+            description: "Topic to focus documentation on (e.g., 'hooks', 'routing')"
         required:
-          - library
+          - context7CompatibleLibraryID
   server:
     port: 8080
     debug: false

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/inference-gateway/documentation-agent
 go 1.24
 
 require (
+	github.com/go-resty/resty/v2 v2.16.3
 	github.com/inference-gateway/adk v0.9.2
 	github.com/sethvargo/go-envconfig v1.3.0
 	go.uber.org/zap v1.27.0
@@ -26,7 +27,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.24.0 // indirect
-	github.com/go-resty/resty/v2 v2.16.3 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inference-gateway/sdk v1.10.0 // indirect


### PR DESCRIPTION
Implements the GetLibraryIDTool feature as requested in #6.

## Summary
Implemented Context7 API integration for library ID resolution and documentation fetching with direct REST API calls, bypassing MCP protocol overhead while maintaining full compatibility.

## Changes
- Implement resolve_library_id tool with direct Context7 API integration
- Enhance get_library_docs tool with Context7-compatible parameters
- Add intelligent library selection logic based on Context7 MCP patterns
- Update agent.yaml with correct tool schemas
- Add comprehensive documentation in IMPLEMENTATION.md
- Support environment variable configuration (CONTEXT7_API_KEY)
- Handle authentication, error responses, and edge cases

## Testing
- Go code compiles successfully
- Passes go vet checks
- All dependencies properly managed

Fixes #6

Generated with [Claude Code](https://claude.ai/code)