### PR TITLE
docs: author spec.documentation and spec.examples in agent.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,25 @@ infer agents add documentation-agent http://localhost:8080 \
 | `resolve_library_id` | Resolves library name to Context7-compatible library ID and returns matching libraries | libraryName, query |
 | `get_library_docs` | Fetches up-to-date documentation for a library using Context7-compatible library ID | libraryId, query |
 
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| Resolve a library name to a Context7 ID | Ask "What is the Context7 ID for Next.js?" and the agent calls resolve_library_id to return matching libraries with their '/org/project' identifiers. |
+| Fetch topic-scoped documentation for a library | Ask "How do I set up JWT auth in Express.js?" and the agent resolves the library, then calls get_library_docs to return focused, up-to-date documentation for that specific topic. |
+| Look up version-specific API behavior | Provide a versioned ID such as '/vercel/next.js/v14.3.0-canary.87' and ask about the App Router; the agent fetches documentation scoped to that exact version. |
+| End-to-end library documentation lookup | Give a bare library name and a question; the library-documentation-lookup skill guides the agent to resolve the ID first, then retrieve the relevant docs in a single flow. |
+
 ## Skills (loaded into the system prompt)
 
 | Skill | Description | Source |
 |-------|-------------|--------|
 | `library-documentation-lookup` | Use this when you need up-to-date documentation for a third-party library or framework before writing code against it. First resolves the library name to a Context7-compatible ID via resolve_library_id when the caller does not already know it (format '/org/project' or '/org/project/version'), then fetches focused, topic-scoped documentation via get_library_docs. Good for filling in unknowns about specific APIs, hooks, configuration options, or version-specific behavior. | bare scaffold (`skills/library-documentation-lookup.md`) |
+
+## Documentation
+- [Getting Started](docs/getting-started.md)
+- [Configuration](docs/configuration.md)
+- [Usage](docs/usage.md)
 
 ## Configuration
 

--- a/agent.yaml
+++ b/agent.yaml
@@ -93,6 +93,38 @@ spec:
       vendor:
         deps: []
         devdeps: []
+  documentation:
+    pages:
+      - title: Getting Started
+        path: docs/getting-started.md
+        description: Install, configure an LLM provider, run the agent, and send your first documentation query.
+      - title: Configuration
+        path: docs/configuration.md
+        description: Environment variables and LLM provider settings specific to this agent.
+      - title: Usage
+        path: docs/usage.md
+        description: How the resolve_library_id and get_library_docs tools and the library-documentation-lookup skill work together.
+  examples:
+    - title: Resolve a library name to a Context7 ID
+      description: >-
+        Ask "What is the Context7 ID for Next.js?" and the agent calls
+        resolve_library_id to return matching libraries with their
+        '/org/project' identifiers.
+    - title: Fetch topic-scoped documentation for a library
+      description: >-
+        Ask "How do I set up JWT auth in Express.js?" and the agent resolves the
+        library, then calls get_library_docs to return focused, up-to-date
+        documentation for that specific topic.
+    - title: Look up version-specific API behavior
+      description: >-
+        Provide a versioned ID such as '/vercel/next.js/v14.3.0-canary.87' and ask
+        about the App Router; the agent fetches documentation scoped to that exact
+        version.
+    - title: End-to-end library documentation lookup
+      description: >-
+        Give a bare library name and a question; the library-documentation-lookup
+        skill guides the agent to resolve the ID first, then retrieve the relevant
+        docs in a single flow.
   scm:
     provider: github
     url: "https://github.com/inference-gateway/documentation-agent"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,44 @@
+# Configuration
+
+The agent is configured through environment variables (most use the `A2A_`
+prefix). This page lists the settings most relevant to
+`documentation-agent`; see the project README for the complete table.
+
+## LLM provider
+
+The agent uses an OpenAI-compatible client to drive tool calls.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `A2A_AGENT_CLIENT_PROVIDER` | LLM provider: `openai`, `anthropic`, `azure`, `ollama`, `deepseek` | `deepseek` |
+| `A2A_AGENT_CLIENT_MODEL` | Model identifier | `deepseek-v4-flash` |
+| `A2A_AGENT_CLIENT_API_KEY` | Provider API key | `sk-...` |
+| `A2A_AGENT_CLIENT_BASE_URL` | Custom endpoint (e.g. an Inference Gateway) | `http://inference-gateway:8080/v1` |
+
+## Context7 access
+
+The `resolve_library_id` and `get_library_docs` tools call Context7. Provide
+an API key for authenticated access:
+
+| Variable | Description |
+|----------|-------------|
+| `CONTEXT7_API_KEY` | Context7 API key. Optional — the agent logs a warning and proceeds unauthenticated when unset, but requests may be rate-limited or rejected with HTTP 401. |
+
+## Server
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_PORT` | Server port | `8080` |
+| `A2A_DEBUG` | Enable debug logging | `false` |
+| `A2A_AGENT_URL` | Public URL used in the agent card | `http://localhost:8080` |
+| `A2A_SERVER_READ_TIMEOUT` / `A2A_SERVER_WRITE_TIMEOUT` / `A2A_SERVER_IDLE_TIMEOUT` | HTTP timeouts | `120s` |
+
+## Capabilities
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `A2A_CAPABILITIES_STREAMING` | Stream responses over SSE | `true` |
+| `A2A_CAPABILITIES_STATE_TRANSITION_HISTORY` | Record task state transitions | `true` |
+
+A ready-to-copy starting point lives in
+[`example/.env.agent.example`](../example/.env.agent.example).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,61 @@
+# Getting Started
+
+`documentation-agent` is an A2A (Agent-to-Agent) server that provides
+Context7-style documentation retrieval. It resolves library names to
+Context7-compatible IDs and fetches up-to-date, topic-scoped documentation
+that other agents can consume over the A2A protocol.
+
+## Prerequisites
+
+- Go 1.26.4+ (or Docker)
+- An OpenAI-compatible LLM endpoint (see [Configuration](configuration.md))
+- A [Context7](https://context7.com) API key (optional but recommended)
+
+## Install and run
+
+```bash
+# Run directly
+go run . start
+
+# Or build the CLI and run the binary
+task build
+./bin/documentation-agent start
+
+# Or with Docker
+docker build -t documentation-agent .
+docker run -p 8080:8080 documentation-agent
+```
+
+The server listens on port `8080` by default (override with `A2A_PORT`).
+
+## Configure the LLM provider
+
+The agent needs an LLM to decide when to call its tools. At minimum set:
+
+```bash
+export A2A_AGENT_CLIENT_PROVIDER=deepseek      # openai | anthropic | azure | ollama | deepseek
+export A2A_AGENT_CLIENT_MODEL=deepseek-v4-flash
+export A2A_AGENT_CLIENT_API_KEY=<your-key>     # or A2A_AGENT_CLIENT_BASE_URL for a gateway
+```
+
+See [Configuration](configuration.md) for the full list.
+
+## Send your first query
+
+With the server running, use the A2A Debugger to submit a task:
+
+```bash
+docker run --rm -it --network host \
+  ghcr.io/inference-gateway/a2a-debugger:latest \
+  --server-url http://localhost:8080 \
+  tasks submit "What is the Context7 ID for Next.js?"
+```
+
+Check that the agent is healthy and inspect its capabilities:
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/.well-known/agent-card.json
+```
+
+Next: [Configuration](configuration.md) · [Usage](usage.md)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,56 @@
+# Usage
+
+`documentation-agent` answers documentation questions about third-party
+libraries and frameworks. Send it a task over the A2A protocol and it
+resolves the library, fetches the relevant docs, and answers from them.
+
+## Tools
+
+| Tool | Inputs | Purpose |
+|------|--------|---------|
+| `resolve_library_id` | `libraryName`, `query` | Resolve a library name (e.g. `Next.js`) to a Context7-compatible ID (`/org/project` or `/org/project/version`) and return matching candidates. |
+| `get_library_docs` | `libraryId`, `query` | Fetch focused, topic-scoped documentation for a resolved or caller-supplied ID. |
+| `Read` | `file_path`, `offset`, `limit` | Read a file from disk (used to load skill playbooks on demand). |
+
+## Skill: library-documentation-lookup
+
+The bundled `library-documentation-lookup` skill tells the agent how to chain
+the two tools:
+
+1. Identify the library and form a specific `query`
+   (e.g. "How to set up JWT auth in Express.js", not just "auth").
+2. Call `resolve_library_id` to get the Context7 ID — unless the caller
+   already supplied one in `/org/project[/version]` form.
+3. Call `get_library_docs` with that ID and the same specific query.
+4. Answer from the returned documentation, citing the library ID used.
+
+The agent will not call the tools more than three times for a single request.
+
+## Example queries
+
+Assuming the agent is running on `http://localhost:8080`:
+
+```bash
+DEBUG="docker run --rm -it --network host ghcr.io/inference-gateway/a2a-debugger:latest --server-url http://localhost:8080"
+
+# Resolve a name to a Context7 ID
+$DEBUG tasks submit "What is the Context7 ID for Next.js?"
+
+# Fetch topic-scoped documentation
+$DEBUG tasks submit "How do I set up JWT auth in Express.js?"
+
+# Ask about a specific version
+$DEBUG tasks submit "Show App Router changes in /vercel/next.js/v14.3.0-canary.87"
+
+# Inspect submitted tasks
+$DEBUG tasks list
+$DEBUG tasks get <task-id>
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Invalid Context7 API key` | `CONTEXT7_API_KEY` missing or wrong | Set a valid key (see [Configuration](configuration.md)). |
+| `Library not found: ...` | Malformed or unpublished ID | Re-run `resolve_library_id`, or pass a correct `/org/project` ID. |
+| `Using mock response - MCP integration pending` | Upstream returned no result | Treat the response as a low-confidence fallback. |


### PR DESCRIPTION
Adds the spec.documentation and spec.examples sections to agent.yaml, supported by adl-cli v0.49.0+ but skipped by adl init --defaults.

Changes:
- spec.examples: 4 entries with title and description covering the agent's Context7 documentation-lookup capabilities.
- spec.documentation.pages: 3 hand-written pages under docs - Getting Started, Configuration, Usage.
- Regenerated README so the new Examples and Documentation sections render.

Notes:
- adl validate agent.yaml passes.
- No changes to spec.tools, spec.skills, spec.config, or spec.services.

Closes #65

Generated with Claude Code